### PR TITLE
DOC: couple of little things on first looking into

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,7 @@ copy, just clone the repo:
    
     git clone git@github.com:simoninireland/simplicial.git
     cd simplicial
+    make setup.py
     python setup.py install
 
 

--- a/simplicial/__init__.py
+++ b/simplicial/__init__.py
@@ -25,10 +25,10 @@ plane. A :term:`complex` is built from simplices (singular:
 :term:`simplex`), and can be used for a number of purposes: as
 discrete approximations of continuous spaces or manifolds, or as
 abstract descriptions of information relationships that can then be
-explored and anlysed using techniques from algebraic :term:`topology`.
+explored and analysed using techniques from algebraic :term:`topology`.
 
 `simplicial` provides a class :class:`SimplicialComplex` to
-represents complexes and provide some topological operations. It also
+represent complexes and provide some topological operations. It also
 provides some "standard" complexes, typically representatives of a
 particularly structured class of spaces, that can be used as building
 blocks for larger complexes. It also provides a function to "embed"


### PR DESCRIPTION
* couple of spelling/grammar things on the first page of readthedocs
* While `pip install simplicial` works, the directions for cloning & installing don't, needing the `make setup.py`.